### PR TITLE
KEYCLOAK-17888: This reverts [KEYCLOAK-14299] restore bootstrap cert provisioning

### DIFF
--- a/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
+++ b/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
@@ -71,7 +71,7 @@ public class DefaultKeyManager implements KeyManager {
                 List<KeyProvider> providers = getProviders(realm);
                 activeKey = getActiveKey(providers, realm, use, algorithm);
                 if (activeKey != null) {
-                    logger.infov("No keys found for realm={0} and algorithm={1} for use={2}. Generating keys.", realm.getName(), algorithm, use.name());
+                    logger.warnv("No keys found for realm={0} and algorithm={1} for use={2}. Generating keys.", realm.getName(), algorithm, use.name());
                     return activeKey;
                 } else {
                     break;

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -18,6 +18,7 @@ package org.keycloak.services.managers;
 
 import org.keycloak.Config;
 import org.keycloak.common.Version;
+import org.keycloak.common.Profile;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
@@ -86,6 +87,8 @@ public class ApplianceBootstrap {
         realm.setRegistrationEmailAsUsername(false);
 
         session.getContext().setRealm(realm);
+        DefaultKeyProviders.createProviders(realm);
+
 
         return true;
     }


### PR DESCRIPTION
Do not delete this PR/Branch.

We are currently using the build from this fork. See https://stax.atlassian.net/browse/DT-515

May be deleted once we are back on the mainline.